### PR TITLE
Fix correctness bugs, containerise, add CI and kw deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+.github/
+deploy/
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ env:
 jobs:
   test:
     runs-on: arc-azrtydxb
+    # The runner image ships no Rust, so the toolchain comes from a container —
+    # same base as the Dockerfile, so CI and the image agree on the compiler.
+    container:
+      image: rust:1-bookworm
     steps:
       - uses: actions/checkout@v4
       - name: Toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: 192.168.10.123:5000
+  IMAGE: 192.168.10.123:5000/azrtydxb/fastllm-proxy/proxy
+
+jobs:
+  test:
+    runs-on: arc-azrtydxb
+    steps:
+      - uses: actions/checkout@v4
+      - name: Toolchain
+        run: rustup component add rustfmt clippy
+      - name: Format
+        run: cargo fmt --all --check
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Test
+        run: cargo test --locked
+
+  publish:
+    # Only what lands on main or a tag becomes an image; a PR just gets tested.
+    if: github.event_name != 'pull_request'
+    needs: test
+    runs-on: arc-azrtydxb-publish
+    steps:
+      - uses: actions/checkout@v4
+
+      # Every build gets an immutable sha- tag. The moving `main` tag and a
+      # semver tag are only added when the ref actually warrants them, so a
+      # workflow_dispatch on a branch cannot quietly redefine what `:main` is.
+      - name: Compute tags
+        id: meta
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE}:sha-${GITHUB_SHA::7}"
+            [ "${GITHUB_REF}" = "refs/heads/main" ] && echo "${IMAGE}:main"
+            [ "${GITHUB_REF_TYPE}" = "tag" ] && echo "${IMAGE}:${GITHUB_REF_NAME#v}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+        env:
+          IMAGE: ${{ env.IMAGE }}
+
+      - name: Set up buildx (zot insecure, Docker Hub via cluster mirror)
+        run: |
+          cat > /tmp/buildkitd.toml <<'EOF'
+          [registry."192.168.10.123:5000"]
+            insecure = true
+          # Pull base images through the cluster's Zot pull-through cache rather
+          # than hitting Docker Hub anonymously and collecting 429s.
+          [registry."docker.io"]
+            mirrors = ["192.168.10.123:5000"]
+          EOF
+          docker buildx create --name fastllm --driver docker-container \
+            --platform linux/arm64 --buildkitd-config /tmp/buildkitd.toml --use
+          docker buildx inspect --bootstrap
+
+      - name: Build & push (arm64 → zot)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          builder: fastllm
+          # arm64 only: every node in kw is arm64, and a Rust release build
+          # under QEMU is not worth the wall clock.
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/buildcache/fastllm-proxy:arm64
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/buildcache/fastllm-proxy:arm64,mode=max,image-manifest=true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -93,6 +93,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -147,6 +157,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -173,16 +199,25 @@ dependencies = [
  "http",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "parking_lot",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
+ "smallvec",
  "tokio",
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-channel"
@@ -214,6 +249,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -292,6 +338,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -386,7 +449,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -395,7 +458,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -409,6 +472,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -484,6 +553,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,10 +625,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -567,6 +728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,7 +756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -597,6 +764,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -641,7 +814,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -653,6 +826,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -741,6 +924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,10 +957,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -781,6 +988,76 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ readme = "README.md"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "signal", "time", "sync"] }
 hyper = { version = "1", features = ["server", "client", "http1"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "server", "http1", "tokio"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["native-tokio", "webpki-tokio", "http1", "tls12", "ring"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 http-body-util = "0.1"
 http = "1"
 bytes = "1"
@@ -25,6 +27,7 @@ anyhow = "1"
 arc-swap = "1"
 parking_lot = "0.12"
 pin-project-lite = "0.2"
+smallvec = "1"
 
 [profile.release]
 opt-level = 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# syntax=docker/dockerfile:1.7
+#
+# Built natively on the arm64 runners rather than under QEMU: the kw cluster is
+# arm64 throughout, and emulating a Rust release build with LTO is far slower
+# than it is worth.
+
+FROM rust:1-bookworm AS build
+WORKDIR /src
+
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+
+# Cache mounts are not part of the resulting layer, so the binary has to be
+# copied out of the target directory inside the same step that produced it.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/src/target,sharing=locked \
+    cargo build --release --locked \
+ && cp target/release/fastllm-proxy /usr/local/bin/fastllm-proxy
+
+FROM debian:bookworm-slim
+
+# ca-certificates is what makes an `https://` api_base work: the proxy prefers
+# the system root store and only falls back to its bundled copy.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --uid 65532 --user-group --no-create-home --shell /usr/sbin/nologin fastllm
+
+COPY --from=build /usr/local/bin/fastllm-proxy /usr/local/bin/fastllm-proxy
+
+USER 65532:65532
+EXPOSE 4000
+
+# Loopback is the right default for a binary someone runs on a workstation, and
+# the wrong one for a container, where the kubelet has to reach it.
+ENV FASTLLM_HOST=0.0.0.0 \
+    FASTLLM_PORT=4000 \
+    FASTLLM_CONFIG=/etc/fastllm/config.yaml
+
+ENTRYPOINT ["/usr/local/bin/fastllm-proxy"]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kill -HUP $(pgrep -x fastllm-proxy)
 |---|---|
 | `POST /v1/chat/completions` | Proxied. Also `/completions`, `/embeddings`, `/rerank`, `/score`, `/audio/*` |
 | `GET /v1/models` | Aggregated across every pool |
-| `GET /health` | Per-backend health, in-flight, request and error counts. No auth required |
+| `GET /health` | Per-backend health, in-flight, request and error counts. No auth required. Exposes backend addresses — keep it off the public interface |
 | `GET /metrics` | Prometheus text. No auth required |
 
 ### Options
@@ -125,6 +125,9 @@ fastllm:
 
 - **Retries** only happen before any byte has been forwarded. Once the response is committed a mid-stream failure propagates as-is — it cannot be silently retried without corrupting the stream.
 - **5xx is retried, 4xx is not.** A client error retried across every node is the same client error three times.
+- **The last backend's response is forwarded verbatim.** A 5xx is only retried while another backend remains; when none does, the upstream's own status and body reach the client rather than a synthetic 502. On a single-node pool that means every error keeps the engine's diagnostics.
+- **Audio endpoints take `multipart/form-data`.** `model` is read from the form field and the upload is forwarded byte for byte, content-type and boundary intact. An alias splices the new name into that one field rather than re-encoding the body.
+- **`https://` backends work**, so a TLS-terminated or hosted endpoint can sit in the same config as cluster-local nodes. System root certificates are used, falling back to the bundled Mozilla set.
 - **A backend that fails every probe is still used as a last resort** rather than returning 503. A stale health flag should not turn a recoverable request into an outage.
 - **The client's `Authorization` header is never forwarded.** It authenticates the client to the proxy; the upstream gets the backend's own key or none.
 - **Affinity keys hash the raw request prefix**, not parsed fields. JSON does not guarantee field order, but order is stable per client, which is all affinity needs — a client that reorders per request degrades to least-loaded rather than misrouting.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,78 @@
+# TODO
+
+Performance backlog, with the measurements that justify (or kill) each item.
+
+Numbers come from `cargo build --release` on a 10-core arm64 macOS host, driven
+by a mock SSE upstream that flushes every frame with no think time — the worst
+case for framing overhead. A real vLLM batches tokens, so production numbers
+should be better than these. Re-measure before acting on any of this.
+
+## Context: where the time goes today
+
+- **Streaming cost is per-frame, not per-byte.** Same bytes, same event count,
+  only the framing changed: 500 single-event frames → 77 MiB/s; 5 hundred-event
+  frames → 2918 MiB/s. The byte pump is fine at ~3 GB/s. The ceiling is roughly
+  **650k frames/s** regardless of frame size.
+- **That ceiling is the upstream client, not this code.** Instrumenting
+  frames-in vs frames-out gave a ratio of exactly **1.000**: a second frame is
+  never already available when the first is consumed. `hyper-util`'s pooled
+  client runs each connection in its own task and hands body chunks over a
+  1-deep want/give channel, so every SSE frame costs a task wakeup, usually
+  cross-thread. A profile agrees — ~28% of samples in `__psynch_cvwait`,
+  `__workq_kernreturn` and `kevent`.
+- **The request path is ~2% of a request.** All of this proxy's own per-request
+  work measures ~0.76µs (URL format + `Uri` parse 156ns, bearer header 92ns,
+  header copy 97ns, `BodyPeek` parse 229ns at 1KiB, prefix hash 108ns, path
+  allocations 41ns) against ~38µs of core time per request. The rest is kernel,
+  socket and hyper protocol work.
+
+**None of this is urgent.** Ten vLLM nodes at 2000 tok/s each is ~20k frames/s
+against a 650k ceiling — about 3% utilised — and the added per-token latency is
+~1.5µs against inter-token gaps of ~500µs. Do these only if the proxy is
+measurably in the way.
+
+## Worth doing, hardest first
+
+### 1. Own the upstream connection instead of using the pooled client
+
+Replace `hyper_util::client::legacy::Client` with `hyper::client::conn::http1`,
+driven on the same task as the response body, plus a small connection pool of
+our own (keep-alive, idle eviction, per-backend caps).
+
+This is the only change that targets the actual ceiling: it removes the
+per-frame cross-task handoff and makes frame coalescing possible for the first
+time. It also means owning pooling correctness, which the current client gives
+us for free.
+
+**Unverified** — prototype against `scratchpad/bench` and confirm the frames/s
+gain before committing to it.
+
+### 2. Byte-level relay after the response is committed
+
+Once headers are forwarded the proxy never looks at the body again, so it could
+copy raw socket bytes rather than decoding and re-encoding chunk framing. This
+is as fast as a proxy gets.
+
+The cost is connection reuse: without tracking chunk framing there is no way to
+know where one response ends and the next begins, so it implies closing the
+upstream connection per request unless the framing is tracked anyway. Probably
+only worth it in combination with (1).
+
+### 3. Re-measure against a real vLLM node
+
+Everything above assumes the mock's flush-per-token behaviour. Under real
+batching the merge ratio is likely above 1.000, which would make coalescing
+(see below) worth reviving on its own. Measure before building anything.
+
+## Measured and rejected — do not retry without new evidence
+
+- **Coalescing already-arrived frames in `TrackedBody`.** 1301 → 1318 req/s,
+  merge ratio 1.000. Cannot help while the client hands over one chunk per
+  round trip. Revisit only after item 1 or 3.
+- **Hand-rolled `model` scanner to skip the JSON parse.** 67.1k → 67.2k req/s
+  on 64KiB bodies. `serde_json` skips what it does not want at ~16 B/ns and the
+  parse is ~3% of a request; a bespoke parser on the routing path is not worth
+  the risk of misrouting.
+- **Pre-parsed `Uri` per backend per endpoint.** ~0.2%, and it forces an
+  endpoint-index coupling between `proxy.rs` and `registry.rs`.
+- **Anything else on the request path.** There is under 1µs available in total.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,71 @@
+# Deploying to the kw cluster
+
+Plain manifests — one Deployment does not earn a Helm chart.
+
+| | |
+|---|---|
+| Namespace | `fastllm` |
+| Image | `192.168.10.123:5000/azrtydxb/fastllm-proxy/proxy:main` (zot, anonymous pull) |
+| VIP | `192.168.10.126` via kube-vip |
+| Backend | spark2 `192.168.10.245:40045/v1`, model `qwen3-6-35b-a3b-nvfp4` |
+
+## First install
+
+The master key is deliberately not in git. Generate one and create the Secret:
+
+```bash
+kubectl create namespace fastllm --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n fastllm create secret generic fastllm-proxy-auth \
+  --from-literal=master-key="sk-$(openssl rand -hex 24)"
+
+kubectl apply -f deploy/
+```
+
+Read the key back when you need it for a client:
+
+```bash
+kubectl -n fastllm get secret fastllm-proxy-auth \
+  -o jsonpath='{.data.master-key}' | base64 -d
+```
+
+## Using it
+
+```bash
+curl http://192.168.10.126/v1/chat/completions \
+  -H "Authorization: Bearer $KEY" \
+  -H 'content-type: application/json' \
+  -d '{"model":"qwen3-6-35b-a3b-nvfp4",
+       "messages":[{"role":"user","content":"hello"}],
+       "max_tokens":400}'
+```
+
+`max_tokens` matters: Qwen3.6 is a thinking model and, with the qwen3 reasoning
+parser, a short limit puts every token in `reasoning_content` and returns an
+empty `content` — which looks like a broken deployment when it is not.
+
+`/health` and `/metrics` need no auth, so probes and Prometheus work without a
+key. Both expose backend addresses, so keep the VIP on the trusted network.
+
+## Changing the model set
+
+Edit `configmap.yaml`, `kubectl apply -f deploy/configmap.yaml`, and wait.
+No rollout is needed: the proxy hashes the mounted file every 5s and reloads
+in place, so generations in flight survive the change. Budget up to ~60s for
+the kubelet to refresh the mount, then one poll interval.
+
+An edit that leaves the file invalid is logged once and ignored — the previous
+config keeps serving.
+
+## When spark2's port changes
+
+GPUStack assigns the replica port and it moves on redeploy. If the backend goes
+unhealthy, find the current one:
+
+```bash
+curl -H "Authorization: Bearer $GPUSTACK_KEY" \
+  http://192.168.10.125/v2/model-instances
+```
+
+then update `api_base` in the ConfigMap. This is the main thing a discovery
+source would automate later.

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fastllm-proxy-config
+  namespace: fastllm
+data:
+  # Edit and re-apply to change the model set. The proxy hashes this file every
+  # few seconds and reloads itself when it changes, so a ConfigMap edit applies
+  # without a rollout and without dropping generations in flight. Allow up to
+  # ~60s for the kubelet to refresh the mounted copy, then ~5s for the poll.
+  config.yaml: |
+    model_list:
+      # spark2 (gx10-9c17). The direct per-replica endpoint, deliberately not
+      # the higress gateway on 192.168.10.125: going straight to the replica is
+      # what lets this proxy do its own prefix-affinity routing instead of the
+      # gateway round-robining across replicas and shredding the KV cache.
+      #
+      # NOTE: GPUStack assigns this port and it changes on redeploy. If the
+      # backend goes unhealthy, look the current one up with
+      #   curl -H "Authorization: Bearer $GPUSTACK_KEY" \
+      #     http://192.168.10.125/v2/model-instances
+      - model_name: qwen3-6-35b-a3b-nvfp4
+        litellm_params:
+          model: openai/qwen3-6-35b-a3b-nvfp4
+          api_base: http://192.168.10.245:40045/v1
+
+    fastllm:
+      # One replica today, so affinity has nothing to choose between. These are
+      # the defaults, written out so they are easy to tune when .246 returns
+      # from ASUS and the pool goes back to two.
+      prefix_bytes: 2048
+      balance_abs: 8
+      balance_rel: 1.5
+      unhealthy_after: 2

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastllm-proxy
+  namespace: fastllm
+  labels: { app: fastllm-proxy }
+spec:
+  replicas: 2
+  selector:
+    matchLabels: { app: fastllm-proxy }
+  strategy:
+    rollingUpdate: { maxUnavailable: 0, maxSurge: 1 }
+  template:
+    metadata:
+      labels: { app: fastllm-proxy }
+    spec:
+      # Two replicas on different nodes: a gateway that dies with one node is
+      # not a gateway. Prefix affinity is per-process, so two replicas means a
+      # prefix can land on either — acceptable at one backend, worth revisiting
+      # if the backend pool grows and cache locality starts to matter.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: { app: fastllm-proxy }
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: proxy
+          image: 192.168.10.123:5000/azrtydxb/fastllm-proxy/proxy:main
+          imagePullPolicy: Always
+          args:
+            - --policy=cache-affinity
+            # spark2 holds 262k context and generations run long; bound only
+            # time-to-first-byte, never the generation itself.
+            - --upstream-timeout=120
+            - --health-interval=10
+          ports:
+            - { name: http, containerPort: 4000 }
+          env:
+            - name: FASTLLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef: { name: fastllm-proxy-auth, key: master-key }
+            - name: FASTLLM_LOG
+              value: info
+          volumeMounts:
+            - { name: config, mountPath: /etc/fastllm, readOnly: true }
+          # Readiness tracks backends: /health is 503 with none healthy, which
+          # correctly pulls this pod out of the Service. Liveness must NOT use
+          # it — spark2 being down would then restart-loop a perfectly healthy
+          # proxy — so it probes /metrics, which answers whenever the process
+          # is alive.
+          readinessProbe:
+            httpGet: { path: /health, port: http }
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet: { path: /metrics, port: http }
+            periodSeconds: 20
+            failureThreshold: 3
+          startupProbe:
+            httpGet: { path: /metrics, port: http }
+            periodSeconds: 3
+            failureThreshold: 20
+          resources:
+            requests: { cpu: 100m, memory: 64Mi }
+            limits: { cpu: "2", memory: 512Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+      volumes:
+        - name: config
+          configMap: { name: fastllm-proxy-config }

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fastllm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fastllm-proxy
+  namespace: fastllm
+  labels: { app: fastllm-proxy }
+  annotations:
+    # kube-vip, matching how the other VIPs on this cluster are requested.
+    # .120-.125 were taken; .126 was free.
+    kube-vip.io/loadbalancerIPs: "192.168.10.126"
+spec:
+  type: LoadBalancer
+  selector: { app: fastllm-proxy }
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: api, port: 4000, targetPort: http }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod health;
+mod multipart;
 mod proxy;
 mod registry;
 mod router;
@@ -12,6 +13,7 @@ use arc_swap::ArcSwap;
 use clap::Parser;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
+use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -128,12 +130,15 @@ async fn run(cli: Cli) -> Result<()> {
     connector.set_nodelay(true);
     connector.set_connect_timeout(Some(Duration::from_secs(5)));
     connector.set_keepalive(Some(Duration::from_secs(60)));
+    // hyper-rustls requires the wrapped connector to permit non-HTTPS URIs; the
+    // https_or_http() policy below is what actually decides per request.
+    connector.enforce_http(false);
 
     let client = Client::builder(TokioExecutor::new())
         .pool_idle_timeout(Duration::from_secs(90))
         .pool_max_idle_per_host(cli.pool_max_idle)
         .retry_canceled_requests(false)
-        .build(connector);
+        .build(https_connector(connector)?);
 
     let master_key = cli
         .master_key
@@ -222,6 +227,32 @@ async fn run(cli: Cli) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Wrap the TCP connector so `https://` api_bases work.
+///
+/// The typical deployment is plain HTTP to nodes on a private network, but the
+/// config schema accepts `https://` and a hosted or TLS-terminated endpoint is
+/// a legitimate backend — accepting the URL and then failing to connect is the
+/// worst of both.
+///
+/// System roots are preferred so an internal CA already trusted by the host
+/// works without extra configuration; the bundled Mozilla set is the fallback
+/// for minimal containers that ship no root store at all.
+fn https_connector(http: HttpConnector) -> Result<HttpsConnector<HttpConnector>> {
+    // Exactly one provider is compiled in, but installing it explicitly keeps
+    // this deterministic rather than dependent on rustls' defaulting rules.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let builder = hyper_rustls::HttpsConnectorBuilder::new();
+    let tls = match builder.with_native_roots() {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "no system root certificates; falling back to the bundled Mozilla set");
+            hyper_rustls::HttpsConnectorBuilder::new().with_webpki_roots()
+        }
+    };
+    Ok(tls.https_or_http().enable_http1().wrap_connector(http))
 }
 
 /// SIGHUP reloads the config in place.

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,11 @@ struct Cli {
     #[arg(long)]
     workers: Option<usize>,
 
+    /// Seconds between checks for an edited config file. 0 disables the watch,
+    /// leaving SIGHUP as the only way to reload.
+    #[arg(long, default_value_t = 5, env = "FASTLLM_CONFIG_POLL")]
+    config_poll: u64,
+
     #[arg(long, default_value = "info", env = "FASTLLM_LOG")]
     log: String,
 }
@@ -176,6 +181,9 @@ async fn run(cli: Cli) -> Result<()> {
         Duration::from_secs(cli.health_timeout.max(1)),
     );
     spawn_reload_listener(Arc::clone(&state));
+    if cli.config_poll > 0 {
+        spawn_config_watcher(Arc::clone(&state), Duration::from_secs(cli.config_poll));
+    }
 
     let addr: SocketAddr = format!("{}:{}", cli.host, cli.port)
         .parse()
@@ -253,6 +261,56 @@ fn https_connector(http: HttpConnector) -> Result<HttpsConnector<HttpConnector>>
         }
     };
     Ok(tls.https_or_http().enable_http1().wrap_connector(http))
+}
+
+/// Reload when the config file's contents change on disk.
+///
+/// Under Kubernetes the config arrives as a ConfigMap, and nothing sends
+/// SIGHUP when it is edited: the kubelet swaps the mount's `..data` symlink
+/// underneath the process and the container never hears about it. Without this
+/// the only way to apply a change is a rollout restart, which drops every
+/// generation in flight — exactly what the SIGHUP path exists to avoid.
+///
+/// Contents are hashed rather than stat'd because that symlink swap does not
+/// reliably move the mtime of the path we opened, and because it makes a
+/// rewrite with identical contents a no-op.
+fn spawn_config_watcher(state: Arc<AppState>, interval: Duration) {
+    tokio::spawn(async move {
+        let hash_now = |path: &std::path::Path| -> Option<u64> {
+            let bytes = std::fs::read(path).ok()?;
+            let mut hash = 0xcbf2_9ce4_8422_2325u64;
+            for b in &bytes {
+                hash = (hash ^ *b as u64).wrapping_mul(0x0000_0100_0000_01b3);
+            }
+            Some(hash)
+        };
+
+        let mut last = hash_now(&state.config_path);
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            let Some(current) = hash_now(&state.config_path) else {
+                // A ConfigMap update is not atomic from the reader's side; a
+                // transiently missing file is normal and the next tick retries.
+                continue;
+            };
+            if last == Some(current) {
+                continue;
+            }
+            // Advance on failure too, so an edit that leaves the file invalid
+            // is reported once rather than every tick. A half-written file is
+            // still retried: the completed write hashes differently and comes
+            // back round as a fresh change.
+            last = Some(current);
+            match state.reload() {
+                Ok(n) => info!(backends = n, "config file changed, reloaded"),
+                Err(e) => {
+                    error!(error = %e, "config file changed but is invalid; keeping previous")
+                }
+            }
+        }
+    });
 }
 
 /// SIGHUP reloads the config in place.

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -1,0 +1,204 @@
+//! Minimal `multipart/form-data` field access.
+//!
+//! The audio endpoints (`/audio/transcriptions`, `/audio/translations`) are
+//! multipart, not JSON. Routing needs exactly one thing out of such a body —
+//! the `model` field — and every other byte, the audio payload above all, has
+//! to reach the upstream untouched.
+//!
+//! So this is a field *locator*, not a parser. It returns the byte range of one
+//! field's value and never materialises the rest; the common path forwards the
+//! original `Bytes` unchanged, and only an alias pays for splicing a new model
+//! name into that range.
+
+use bytes::{Bytes, BytesMut};
+use std::ops::Range;
+
+/// Boundary token from a `Content-Type`, or `None` if this is not multipart.
+pub fn boundary(content_type: &str) -> Option<String> {
+    let (kind, params) = content_type.split_once(';')?;
+    if !kind.trim().eq_ignore_ascii_case("multipart/form-data") {
+        return None;
+    }
+    for param in params.split(';') {
+        let (key, value) = param.split_once('=')?;
+        if key.trim().eq_ignore_ascii_case("boundary") {
+            let value = value.trim().trim_matches('"');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Byte range of the value of the form field named `name`.
+///
+/// Scans parts in order and stops at the first match, so a `model` field placed
+/// before the file part — where every OpenAI client puts it — costs a scan of a
+/// few hundred bytes rather than of the upload.
+pub fn find_field(body: &[u8], boundary: &str, name: &str) -> Option<Range<usize>> {
+    let opening = format!("--{boundary}");
+    let separator = format!("\r\n--{boundary}");
+
+    let mut pos = find(body, opening.as_bytes())? + opening.len();
+    loop {
+        let rest = body.get(pos..)?;
+        // A trailing `--` is the closing boundary: no more parts.
+        if rest.starts_with(b"--") || !rest.starts_with(b"\r\n") {
+            return None;
+        }
+        let headers_start = pos + 2;
+        let headers_end = find(body.get(headers_start..)?, b"\r\n\r\n")? + headers_start;
+        let value_start = headers_end + 4;
+        let value_end = find(body.get(value_start..)?, separator.as_bytes())? + value_start;
+
+        if part_is_named(&body[headers_start..headers_end], name) {
+            return Some(value_start..value_end);
+        }
+        pos = value_end + separator.len();
+    }
+}
+
+/// The field value as a string, trimmed. `None` if it is not valid UTF-8.
+pub fn field_value(body: &[u8], range: Range<usize>) -> Option<&str> {
+    std::str::from_utf8(body.get(range)?).ok().map(str::trim)
+}
+
+/// Rebuild the body with `value` spliced over `range`.
+pub fn replace_range(body: &Bytes, range: Range<usize>, value: &str) -> Bytes {
+    let mut out = BytesMut::with_capacity(body.len() + value.len());
+    out.extend_from_slice(&body[..range.start]);
+    out.extend_from_slice(value.as_bytes());
+    out.extend_from_slice(&body[range.end..]);
+    out.freeze()
+}
+
+/// Does this part's `Content-Disposition` carry `name="<name>"`?
+fn part_is_named(headers: &[u8], name: &str) -> bool {
+    let Ok(text) = std::str::from_utf8(headers) else {
+        return false;
+    };
+    for line in text.split("\r\n") {
+        let Some((key, params)) = line.split_once(':') else {
+            continue;
+        };
+        if !key.trim().eq_ignore_ascii_case("content-disposition") {
+            continue;
+        }
+        for param in params.split(';') {
+            let Some((key, value)) = param.split_once('=') else {
+                continue;
+            };
+            if key.trim().eq_ignore_ascii_case("name") {
+                return value.trim().trim_matches('"') == name;
+            }
+        }
+    }
+    false
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const B: &str = "----abc123";
+
+    fn form() -> Bytes {
+        Bytes::from(
+            "------abc123\r\n\
+             Content-Disposition: form-data; name=\"model\"\r\n\r\n\
+             whisper-1\r\n\
+             ------abc123\r\n\
+             Content-Disposition: form-data; name=\"file\"; filename=\"a.wav\"\r\n\
+             Content-Type: audio/wav\r\n\r\n\
+             RIFF\x00\x00binary\r\n\
+             ------abc123--\r\n",
+        )
+    }
+
+    #[test]
+    fn extracts_the_boundary() {
+        assert_eq!(
+            boundary("multipart/form-data; boundary=----abc123").as_deref(),
+            Some("----abc123")
+        );
+        // Quoted, oddly cased, and with a charset param in the way.
+        assert_eq!(
+            boundary("Multipart/Form-Data; charset=utf-8; BOUNDARY=\"xy\"").as_deref(),
+            Some("xy")
+        );
+        assert_eq!(boundary("application/json"), None);
+        assert_eq!(boundary("multipart/form-data"), None);
+    }
+
+    #[test]
+    fn finds_a_field_before_the_file_part() {
+        let body = form();
+        let range = find_field(&body, B, "model").unwrap();
+        assert_eq!(field_value(&body, range), Some("whisper-1"));
+    }
+
+    #[test]
+    fn finds_a_field_after_the_file_part() {
+        let body = Bytes::from(
+            "------abc123\r\n\
+             Content-Disposition: form-data; name=\"file\"; filename=\"a.wav\"\r\n\r\n\
+             RIFFdata\r\n\
+             ------abc123\r\n\
+             Content-Disposition: form-data; name=\"model\"\r\n\r\n\
+             whisper-1\r\n\
+             ------abc123--\r\n",
+        );
+        let range = find_field(&body, B, "model").unwrap();
+        assert_eq!(field_value(&body, range), Some("whisper-1"));
+    }
+
+    #[test]
+    fn missing_field_is_none() {
+        assert_eq!(find_field(&form(), B, "temperature"), None);
+    }
+
+    #[test]
+    fn filename_does_not_masquerade_as_the_name() {
+        // `filename="model"` must not be mistaken for `name="model"`.
+        let body = Bytes::from(
+            "------abc123\r\n\
+             Content-Disposition: form-data; name=\"file\"; filename=\"model\"\r\n\r\n\
+             data\r\n\
+             ------abc123--\r\n",
+        );
+        assert_eq!(find_field(&body, B, "model"), None);
+    }
+
+    #[test]
+    fn replacing_the_model_leaves_the_upload_intact() {
+        let body = form();
+        let range = find_field(&body, B, "model").unwrap();
+        let out = replace_range(&body, range, "Systran/faster-whisper-large-v3");
+
+        let range = find_field(&out, B, "model").unwrap();
+        assert_eq!(
+            field_value(&out, range),
+            Some("Systran/faster-whisper-large-v3")
+        );
+        // The binary part survives byte for byte, NUL and all.
+        assert_eq!(
+            find_field(&out, B, "file").map(|r| out.slice(r)),
+            Some(Bytes::from_static(b"RIFF\x00\x00binary"))
+        );
+    }
+
+    #[test]
+    fn a_truncated_body_does_not_panic() {
+        assert_eq!(find_field(b"------abc123\r\nContent-Dis", B, "model"), None);
+        assert_eq!(find_field(b"", B, "model"), None);
+        assert_eq!(find_field(b"not multipart at all", B, "model"), None);
+    }
+}

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -10,20 +10,27 @@
 //! only once, and the original bytes are what get forwarded. The body is only
 //! rebuilt when an alias means the upstream model name differs from the one the
 //! client asked for.
+//!
+//! Two body encodings show up on these endpoints: JSON everywhere, and
+//! `multipart/form-data` on the audio routes. Both are handled the same way —
+//! locate `model`, forward the original bytes — so an upload never gets
+//! re-encoded on its way through.
 
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full, Limited};
 use hyper::body::{Body, Frame, Incoming};
-use hyper::header::{HeaderName, HeaderValue};
+use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use hyper::{HeaderMap, Method, Request, Response, StatusCode};
 use pin_project_lite::pin_project;
 use serde::Deserialize;
+use std::ops::Range;
 use std::pin::Pin;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tracing::{debug, warn};
 
+use crate::multipart;
 use crate::registry::{Backend, BackendUid, InflightGuard};
 use crate::state::AppState;
 
@@ -40,7 +47,7 @@ const PROXIED_SUFFIXES: &[&str] = &[
     "/audio/translations",
 ];
 
-/// Headers that must not be copied between hops.
+/// Per-connection headers, meaningless on the next hop in either direction.
 const HOP_BY_HOP: &[&str] = &[
     "connection",
     "keep-alive",
@@ -50,10 +57,18 @@ const HOP_BY_HOP: &[&str] = &[
     "trailer",
     "transfer-encoding",
     "upgrade",
-    "host",
-    "content-length",
-    "authorization",
 ];
+
+/// Additionally dropped from the client's request before it goes upstream.
+///
+/// `host` and `content-length` describe the old hop and are regenerated;
+/// `authorization` authenticates the client to *this* proxy and must never
+/// leak onward — the upstream gets the backend's own key or nothing.
+///
+/// Note that `content-length` is deliberately absent from the response side:
+/// the body is forwarded byte for byte, so an upstream length stays accurate
+/// and stripping it would force needless chunking on ordinary completions.
+const REQUEST_ONLY_STRIPPED: &[&str] = &["host", "content-length", "authorization"];
 
 pub async fn handle(
     req: Request<Incoming>,
@@ -94,6 +109,11 @@ pub async fn handle(
 
 /// Fields the router needs. Everything else in the body is skipped without
 /// being materialised.
+///
+/// Reading `model` off the front of the body with a hand-rolled scan was tried
+/// and reverted: it measured 67.2k vs 67.1k req/s on 64KiB bodies. `serde_json`
+/// skips what it does not want at ~16 B/ns, and the parse is ~3% of the work a
+/// request costs — not worth a bespoke parser on the routing path.
 #[derive(Deserialize)]
 struct BodyPeek {
     #[serde(default)]
@@ -111,36 +131,86 @@ async fn proxy_request(
 
     let collected = match Limited::new(body, state.max_body_bytes).collect().await {
         Ok(c) => c.to_bytes(),
-        Err(_) => {
-            return error_response(
-                StatusCode::PAYLOAD_TOO_LARGE,
-                "payload_too_large",
-                &format!("request body exceeds {} bytes", state.max_body_bytes),
-            )
-        }
-    };
-
-    let peek: BodyPeek = match serde_json::from_slice(&collected) {
-        Ok(p) => p,
         Err(e) => {
-            return error_response(
-                StatusCode::BAD_REQUEST,
-                "invalid_request_error",
-                &format!("request body is not valid JSON: {e}"),
-            )
+            state.requests_failed.fetch_add(1, Ordering::Relaxed);
+            // A body that outgrew the cap and a client that vanished mid-upload
+            // are different failures and deserve different statuses.
+            return if e
+                .downcast_ref::<http_body_util::LengthLimitError>()
+                .is_some()
+            {
+                error_response(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "payload_too_large",
+                    &format!("request body exceeds {} bytes", state.max_body_bytes),
+                )
+            } else {
+                error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    &format!("could not read the request body: {e}"),
+                )
+            };
         }
     };
 
-    let Some(model) = peek.model.filter(|m| !m.is_empty()) else {
-        return error_response(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            "request body is missing the 'model' field",
-        );
+    let content_type = parts
+        .headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    let (model, model_field, streaming) = match multipart::boundary(content_type) {
+        // Multipart: the audio routes. `model` is a form field, and the rest of
+        // the body — the upload — must not be touched.
+        Some(boundary) => {
+            let Some(range) = multipart::find_field(&collected, &boundary, "model") else {
+                state.requests_failed.fetch_add(1, Ordering::Relaxed);
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    "multipart body is missing the 'model' field",
+                );
+            };
+            match multipart::field_value(&collected, range.clone()).filter(|m| !m.is_empty()) {
+                Some(model) => (model.to_string(), Some(range), false),
+                None => {
+                    state.requests_failed.fetch_add(1, Ordering::Relaxed);
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request_error",
+                        "the 'model' form field is empty or not valid UTF-8",
+                    );
+                }
+            }
+        }
+        None => {
+            let peek: BodyPeek = match serde_json::from_slice(&collected) {
+                Ok(p) => p,
+                Err(e) => {
+                    state.requests_failed.fetch_add(1, Ordering::Relaxed);
+                    return error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request_error",
+                        &format!("request body is not valid JSON: {e}"),
+                    );
+                }
+            };
+            let Some(model) = peek.model.filter(|m| !m.is_empty()) else {
+                state.requests_failed.fetch_add(1, Ordering::Relaxed);
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    "request body is missing the 'model' field",
+                );
+            };
+            (model, None, peek.stream.unwrap_or(false))
+        }
     };
 
     let registry = state.registry.load();
     let Some(pool) = registry.pool(&model) else {
+        state.requests_failed.fetch_add(1, Ordering::Relaxed);
         let known = registry.model_names().join(", ");
         return error_response(
             StatusCode::NOT_FOUND,
@@ -163,27 +233,33 @@ async fn proxy_request(
         };
         tried.push(backend.uid);
 
-        let upstream_body =
-            match rewrite_model_if_needed(&collected, &model, &backend.upstream_model) {
-                Ok(b) => b,
-                Err(e) => {
-                    return error_response(
-                        StatusCode::BAD_REQUEST,
-                        "invalid_request_error",
-                        &format!("could not rewrite model name for alias: {e}"),
-                    )
-                }
-            };
+        let upstream_body = match rewrite_model_if_needed(
+            &collected,
+            &model,
+            &backend.upstream_model,
+            model_field.clone(),
+        ) {
+            Ok(b) => b,
+            Err(e) => {
+                state.requests_failed.fetch_add(1, Ordering::Relaxed);
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    &format!("could not rewrite model name for alias: {e}"),
+                );
+            }
+        };
 
         let upstream_req =
             match build_upstream_request(&parts.headers, &backend, &subpath, upstream_body) {
                 Ok(r) => r,
                 Err(e) => {
+                    state.requests_failed.fetch_add(1, Ordering::Relaxed);
                     return error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "internal_error",
                         &format!("could not build upstream request: {e}"),
-                    )
+                    );
                 }
             };
 
@@ -208,22 +284,30 @@ async fn proxy_request(
         match result {
             Ok(resp) => {
                 let status = resp.status();
-                // A 5xx before any bytes were forwarded is worth another node.
-                // 4xx is the client's fault and retrying just multiplies it.
-                if status.is_server_error() && attempt < state.max_retries {
-                    backend.note_error();
-                    last_error = Some(format!("upstream {} returned {}", backend.api_base, status));
-                    debug!(backend = %backend.api_base, %status, "retrying on another backend");
-                    continue;
-                }
                 if status.is_server_error() {
                     backend.note_error();
+                    // A 5xx before any bytes were forwarded is worth another
+                    // node — but only if there *is* another node. Retrying into
+                    // an empty candidate set would discard this response and
+                    // answer with a synthetic 502, throwing away the upstream's
+                    // own diagnostics; on a single-node pool that is every 5xx.
+                    // 4xx is the client's fault and retrying just multiplies it.
+                    if attempt < state.max_retries && state.router.has_candidate(&pool, &tried) {
+                        last_error =
+                            Some(format!("upstream {} returned {}", backend.api_base, status));
+                        debug!(backend = %backend.api_base, %status, "retrying on another backend");
+                        continue;
+                    }
                 }
-                state.requests_ok.fetch_add(1, Ordering::Relaxed);
+                if status.is_client_error() || status.is_server_error() {
+                    state.requests_failed.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    state.requests_ok.fetch_add(1, Ordering::Relaxed);
+                }
                 debug!(
                     backend = %backend.api_base,
                     model = %model,
-                    stream = peek.stream.unwrap_or(false),
+                    stream = streaming,
                     %status,
                     "proxied"
                 );
@@ -247,14 +331,20 @@ async fn proxy_request(
 /// bytes when the names already match.
 ///
 /// The common case is a straight `Bytes` clone (a refcount bump). Only aliases
-/// pay for a parse and re-serialise.
+/// pay for a rewrite — and for multipart, `model_field` is the already-located
+/// range of the field value, so even that is a splice rather than a re-encode
+/// of the upload.
 fn rewrite_model_if_needed(
     body: &Bytes,
     requested: &str,
     upstream: &str,
+    model_field: Option<Range<usize>>,
 ) -> Result<Bytes, serde_json::Error> {
     if requested == upstream {
         return Ok(body.clone());
+    }
+    if let Some(range) = model_field {
+        return Ok(multipart::replace_range(body, range, upstream));
     }
     let mut value: serde_json::Value = serde_json::from_slice(body)?;
     if let Some(obj) = value.as_object_mut() {
@@ -277,20 +367,20 @@ fn build_upstream_request(
 
     let headers = builder.headers_mut().expect("builder has no error yet");
     for (name, value) in client_headers.iter() {
-        if HOP_BY_HOP.contains(&name.as_str()) {
+        let name_str = name.as_str();
+        if HOP_BY_HOP.contains(&name_str) || REQUEST_ONLY_STRIPPED.contains(&name_str) {
             continue;
         }
         headers.insert(name.clone(), value.clone());
     }
-    headers.insert(
-        HeaderName::from_static("content-type"),
-        HeaderValue::from_static("application/json"),
-    );
-    if let Some(key) = &backend.api_key {
-        headers.insert(
-            HeaderName::from_static("authorization"),
-            HeaderValue::from_str(&format!("Bearer {key}"))?,
-        );
+    // The client's content-type is carried through untouched — a multipart
+    // upload's boundary parameter lives there, and overwriting it would make
+    // the body unparseable upstream. JSON is only assumed when nothing was set.
+    if !headers.contains_key(CONTENT_TYPE) {
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    }
+    if let Some(auth) = &backend.auth {
+        headers.insert(HeaderName::from_static("authorization"), auth.clone());
     }
 
     Ok(builder.body(Full::new(body))?)
@@ -300,6 +390,8 @@ fn build_upstream_request(
 /// for as long as the body is still streaming.
 fn finish_response(resp: Response<Incoming>, guard: InflightGuard) -> Response<ResBody> {
     let (mut parts, body) = resp.into_parts();
+    // Hop-by-hop only: the response body is passed through byte for byte, so
+    // an upstream `content-length` remains correct and is worth keeping.
     for name in HOP_BY_HOP {
         parts.headers.remove(*name);
     }
@@ -308,6 +400,12 @@ fn finish_response(resp: Response<Incoming>, guard: InflightGuard) -> Response<R
 
 pin_project! {
     /// Passthrough body that releases an [`InflightGuard`] when the stream ends.
+    ///
+    /// Deliberately not batching: merging frames that have already arrived was
+    /// measured at a 1.000 merge ratio, because hyper's pooled client hands the
+    /// body over one chunk per want/give round trip and a second chunk is never
+    /// already waiting. The cost per frame is that handoff, not this wrapper,
+    /// so a coalescing buffer here only adds a poll and a branch.
     struct TrackedBody {
         #[pin]
         inner: Incoming,
@@ -358,8 +456,7 @@ fn check_auth(req: &Request<Incoming>, state: &AppState) -> Option<Response<ResB
         .headers()
         .get(hyper::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "))
-        .map(str::trim);
+        .and_then(bearer_token);
 
     match presented {
         Some(token) if constant_time_eq(token.as_bytes(), expected.as_bytes()) => None,
@@ -371,7 +468,21 @@ fn check_auth(req: &Request<Incoming>, state: &AppState) -> Option<Response<ResB
     }
 }
 
-/// Length-independent comparison, so a wrong key cannot be probed byte by byte.
+/// Token out of an `Authorization` value, if the scheme is Bearer.
+///
+/// RFC 7235 makes the auth scheme case-insensitive, and clients do send
+/// `bearer`; matching only the capitalised form rejects a valid key.
+fn bearer_token(header: &str) -> Option<&str> {
+    let (scheme, token) = header.split_once(' ')?;
+    scheme
+        .eq_ignore_ascii_case("bearer")
+        .then(|| token.trim())
+        .filter(|t| !t.is_empty())
+}
+
+/// Comparison that does not short-circuit on the first differing byte, so a
+/// wrong key cannot be recovered one byte at a time. The length itself is not
+/// hidden — for a bearer token that is not the secret.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
@@ -454,14 +565,14 @@ fn metrics_response(state: &AppState) -> Response<ResBody> {
     let registry = state.registry.load();
     let mut out = String::with_capacity(1024);
 
-    out.push_str("# HELP fastllm_requests_total Requests proxied successfully.\n");
+    out.push_str("# HELP fastllm_requests_total Requests answered with a success status.\n");
     out.push_str("# TYPE fastllm_requests_total counter\n");
     out.push_str(&format!(
         "fastllm_requests_total {}\n",
         state.requests_ok.load(Ordering::Relaxed)
     ));
 
-    out.push_str("# HELP fastllm_requests_failed_total Requests that exhausted every backend.\n");
+    out.push_str("# HELP fastllm_requests_failed_total Requests rejected here, answered with an error status, or that exhausted every backend.\n");
     out.push_str("# TYPE fastllm_requests_failed_total counter\n");
     out.push_str(&format!(
         "fastllm_requests_failed_total {}\n",
@@ -527,7 +638,7 @@ mod tests {
     #[test]
     fn identical_model_names_avoid_a_reserialise() {
         let body = Bytes::from_static(br#"{"model":"m","messages":[]}"#);
-        let out = rewrite_model_if_needed(&body, "m", "m").unwrap();
+        let out = rewrite_model_if_needed(&body, "m", "m", None).unwrap();
         // Same allocation, not a copy.
         assert_eq!(out.as_ptr(), body.as_ptr());
     }
@@ -535,11 +646,46 @@ mod tests {
     #[test]
     fn alias_rewrites_the_model_field() {
         let body = Bytes::from_static(br#"{"model":"gpt-4","messages":[],"temperature":0.7}"#);
-        let out = rewrite_model_if_needed(&body, "gpt-4", "Qwen/Qwen3-30B-A3B").unwrap();
+        let out = rewrite_model_if_needed(&body, "gpt-4", "Qwen/Qwen3-30B-A3B", None).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(parsed["model"], "Qwen/Qwen3-30B-A3B");
         // Other parameters must survive the round trip.
         assert_eq!(parsed["temperature"], 0.7);
+    }
+
+    #[test]
+    fn alias_rewrites_a_multipart_model_without_touching_the_upload() {
+        let body = Bytes::from(
+            "--xy\r\n\
+             Content-Disposition: form-data; name=\"model\"\r\n\r\n\
+             whisper-1\r\n\
+             --xy\r\n\
+             Content-Disposition: form-data; name=\"file\"; filename=\"a.wav\"\r\n\r\n\
+             RIFF\x00\x00audio\r\n\
+             --xy--\r\n",
+        );
+        let range = multipart::find_field(&body, "xy", "model").unwrap();
+        let out =
+            rewrite_model_if_needed(&body, "whisper-1", "Systran/faster-whisper", Some(range))
+                .unwrap();
+
+        let model = multipart::find_field(&out, "xy", "model").unwrap();
+        assert_eq!(
+            multipart::field_value(&out, model),
+            Some("Systran/faster-whisper")
+        );
+        let file = multipart::find_field(&out, "xy", "file").unwrap();
+        assert_eq!(out.slice(file), Bytes::from_static(b"RIFF\x00\x00audio"));
+    }
+
+    #[test]
+    fn multipart_body_is_forwarded_verbatim_when_no_alias() {
+        let body = Bytes::from_static(
+            b"--xy\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\nm\r\n--xy--\r\n",
+        );
+        let range = multipart::find_field(&body, "xy", "model").unwrap();
+        let out = rewrite_model_if_needed(&body, "m", "m", Some(range)).unwrap();
+        assert_eq!(out.as_ptr(), body.as_ptr());
     }
 
     #[test]
@@ -559,11 +705,36 @@ mod tests {
     }
 
     #[test]
+    fn bearer_scheme_is_case_insensitive() {
+        assert_eq!(bearer_token("Bearer sk-abc"), Some("sk-abc"));
+        assert_eq!(bearer_token("bearer sk-abc"), Some("sk-abc"));
+        assert_eq!(bearer_token("BEARER  sk-abc "), Some("sk-abc"));
+        assert_eq!(bearer_token("Basic sk-abc"), None);
+        assert_eq!(bearer_token("Bearer "), None);
+        assert_eq!(bearer_token("sk-abc"), None);
+    }
+
+    #[test]
     fn authorization_is_not_forwarded_from_the_client() {
         // The client's key authenticates it to the proxy; the upstream gets the
         // backend's own key or none at all.
-        assert!(HOP_BY_HOP.contains(&"authorization"));
-        assert!(HOP_BY_HOP.contains(&"content-length"));
-        assert!(HOP_BY_HOP.contains(&"host"));
+        assert!(REQUEST_ONLY_STRIPPED.contains(&"authorization"));
+        assert!(REQUEST_ONLY_STRIPPED.contains(&"content-length"));
+        assert!(REQUEST_ONLY_STRIPPED.contains(&"host"));
+    }
+
+    #[test]
+    fn response_content_length_survives_the_hop() {
+        // Stripping it would force chunked encoding on every non-streaming
+        // completion that arrived with a perfectly good length.
+        assert!(!HOP_BY_HOP.contains(&"content-length"));
+        assert!(HOP_BY_HOP.contains(&"transfer-encoding"));
+    }
+
+    #[test]
+    fn audio_routes_are_proxied() {
+        for route in ["/audio/transcriptions", "/audio/translations"] {
+            assert!(PROXIED_SUFFIXES.contains(&route));
+        }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -7,6 +7,7 @@
 //! the same backend appears in both generations.
 
 use anyhow::{Context, Result};
+use hyper::header::HeaderValue;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
@@ -19,26 +20,42 @@ use crate::config::FileConfig;
 /// The prefix-affinity cache stores these rather than array indices, so a
 /// reload that reorders or resizes the model list does not silently
 /// re-point warm prefixes at the wrong node.
-pub type BackendUid = u16;
+pub type BackendUid = u32;
 
 /// Assigns a stable [`BackendUid`] to each distinct `(api_base, upstream_model)`.
+///
+/// Entries are never removed and a uid is never reused, because the affinity
+/// cache holds uids for warm prefixes: recycling one onto a different backend
+/// would silently misroute them. Reloads that churn the model set therefore
+/// grow the table monotonically — at ~2^32 distinct backends per process
+/// lifetime the ceiling is unreachable in practice, and a few dozen bytes per
+/// backend ever seen is the price of never misrouting.
 #[derive(Default)]
 pub struct Interner {
-    map: Mutex<HashMap<String, BackendUid>>,
+    inner: Mutex<InternerState>,
+}
+
+#[derive(Default)]
+struct InternerState {
+    map: HashMap<String, BackendUid>,
+    /// Tracked separately from `map.len()` so uids stay unique regardless of
+    /// what the map does.
+    next: u64,
 }
 
 impl Interner {
     pub fn intern(&self, api_base: &str, upstream_model: &str) -> Result<BackendUid> {
         let key = format!("{api_base}|{upstream_model}");
-        let mut map = self.map.lock();
-        if let Some(uid) = map.get(&key) {
+        let mut state = self.inner.lock();
+        if let Some(uid) = state.map.get(&key) {
             return Ok(*uid);
         }
-        let next = map.len();
-        let uid: BackendUid = next
+        let uid: BackendUid = state
+            .next
             .try_into()
-            .context("more than 65536 distinct backends seen over this process's lifetime")?;
-        map.insert(key, uid);
+            .context("more than 4294967295 distinct backends seen over this process's lifetime")?;
+        state.next += 1;
+        state.map.insert(key, uid);
         Ok(uid)
     }
 }
@@ -51,7 +68,9 @@ pub struct Backend {
     pub api_base: String,
     /// Model name to put in the request body sent upstream.
     pub upstream_model: String,
-    pub api_key: Option<String>,
+    /// Ready-made `Authorization` header, built once instead of formatted and
+    /// re-validated on every request. `None` when the upstream needs no key.
+    pub auth: Option<HeaderValue>,
 
     healthy: AtomicBool,
     consecutive_failures: AtomicU32,
@@ -66,12 +85,19 @@ impl Backend {
         api_base: String,
         upstream_model: String,
         api_key: Option<String>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let auth = api_key
+            .as_deref()
+            .map(|key| {
+                HeaderValue::from_str(&format!("Bearer {key}"))
+                    .with_context(|| format!("api_key for {api_base} is not a valid header value"))
+            })
+            .transpose()?;
+        Ok(Self {
             uid,
             api_base,
             upstream_model,
-            api_key,
+            auth,
             // Optimistic: a backend serves traffic until a health check says
             // otherwise. Starting unhealthy would blackhole every request in
             // the window before the first sweep completes.
@@ -80,7 +106,7 @@ impl Backend {
             inflight: AtomicUsize::new(0),
             requests_total: AtomicU64::new(0),
             errors_total: AtomicU64::new(0),
-        }
+        })
     }
 
     #[inline]
@@ -190,14 +216,15 @@ impl Registry {
                 let carried = previous
                     .and_then(|p| p.all.iter().find(|b| b.uid == uid))
                     .cloned();
-                let backend = carried.unwrap_or_else(|| {
-                    Arc::new(Backend::new(
+                let backend = match carried {
+                    Some(live) => live,
+                    None => Arc::new(Backend::new(
                         uid,
                         api_base.clone(),
                         upstream_model.clone(),
                         entry.litellm_params.effective_api_key(),
-                    ))
-                });
+                    )?),
+                };
                 by_uid.insert(uid, Arc::clone(&backend));
                 backend
             };

--- a/src/router.rs
+++ b/src/router.rs
@@ -16,10 +16,15 @@
 //! rebalance. `balance_abs` / `balance_rel` set how much imbalance is tolerated
 //! before cache locality is given up.
 
+use smallvec::SmallVec;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::registry::{Backend, BackendUid, Pool};
+
+/// Candidate list for one routing decision. Pools are a handful of nodes, so
+/// this stays on the stack and the hot path allocates nothing.
+type Candidates<'a> = SmallVec<[&'a Arc<Backend>; 8]>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum Policy {
@@ -82,7 +87,7 @@ impl Router {
     ///
     /// Returns `None` when every healthy backend has been exhausted.
     pub fn pick(&self, pool: &Pool, prefix: u64, exclude: &[BackendUid]) -> Option<Arc<Backend>> {
-        let candidates: Vec<&Arc<Backend>> = pool
+        let mut candidates: Candidates = pool
             .iter()
             .filter(|b| b.is_healthy() && !exclude.contains(&b.uid))
             .collect();
@@ -90,16 +95,12 @@ impl Router {
         // Everything healthy has already failed — fall back to unhealthy
         // backends rather than returning an error. A stale health flag should
         // not turn a recoverable request into a 503.
-        let candidates = if candidates.is_empty() {
-            let fallback: Vec<&Arc<Backend>> =
-                pool.iter().filter(|b| !exclude.contains(&b.uid)).collect();
-            if fallback.is_empty() {
+        if candidates.is_empty() {
+            candidates = pool.iter().filter(|b| !exclude.contains(&b.uid)).collect();
+            if candidates.is_empty() {
                 return None;
             }
-            fallback
-        } else {
-            candidates
-        };
+        }
 
         if candidates.len() == 1 {
             return Some(Arc::clone(candidates[0]));
@@ -118,6 +119,16 @@ impl Router {
             self.affinity.put(prefix, chosen.uid);
         }
         Some(Arc::clone(chosen))
+    }
+
+    /// Would [`pick`](Self::pick) still find a backend if these were excluded?
+    ///
+    /// Answers the retry question — "is there anywhere else to send this?" —
+    /// without the side effects of actually picking (claiming a prefix,
+    /// advancing the round-robin cursor). Mirrors `pick`'s last-resort rule
+    /// that an unhealthy backend still counts as somewhere to go.
+    pub fn has_candidate(&self, pool: &Pool, exclude: &[BackendUid]) -> bool {
+        pool.iter().any(|b| !exclude.contains(&b.uid))
     }
 
     /// Returns the chosen backend and whether it should claim this prefix.
@@ -158,35 +169,36 @@ impl Router {
 /// deterministic — the same prefix picks the same node even before it is
 /// cached — while distributing distinct prefixes across the cluster.
 fn least_loaded_for<'a>(candidates: &[&'a Arc<Backend>], prefix: u64) -> &'a Arc<Backend> {
-    let min = candidates.iter().map(|b| b.inflight()).min().unwrap_or(0);
-    let tied: Vec<&'a Arc<Backend>> = candidates
-        .iter()
-        .copied()
-        .filter(|b| b.inflight() == min)
-        .collect();
-    let tied = if tied.is_empty() {
-        candidates
-    } else {
-        &tied[..]
-    };
-    tied[(prefix % tied.len() as u64) as usize]
+    pick_tied(candidates, prefix as usize)
 }
 
 /// Least loaded, with ties broken by rotation. Used by the cache-blind policy,
 /// where there is no prefix to spread on.
 fn least_loaded<'a>(candidates: &[&'a Arc<Backend>], rr: &AtomicUsize) -> &'a Arc<Backend> {
+    pick_tied(candidates, rr.fetch_add(1, Ordering::Relaxed))
+}
+
+/// The `selector`-th of the least-loaded candidates.
+///
+/// Two scans over a handful of relaxed atomics and no allocation — this runs
+/// per request. In-flight counts can move between the scans, so the tail
+/// return covers the case where the minimum no longer matches anything; any
+/// candidate is a defensible answer at that point.
+fn pick_tied<'a>(candidates: &[&'a Arc<Backend>], selector: usize) -> &'a Arc<Backend> {
     let min = candidates.iter().map(|b| b.inflight()).min().unwrap_or(0);
-    let tied: Vec<&'a Arc<Backend>> = candidates
-        .iter()
-        .copied()
-        .filter(|b| b.inflight() == min)
-        .collect();
-    let tied = if tied.is_empty() {
-        candidates
-    } else {
-        &tied[..]
-    };
-    tied[rr.fetch_add(1, Ordering::Relaxed) % tied.len()]
+    let tied = candidates.iter().filter(|b| b.inflight() == min).count();
+    if tied > 0 {
+        let mut nth = selector % tied;
+        for b in candidates {
+            if b.inflight() == min {
+                if nth == 0 {
+                    return b;
+                }
+                nth -= 1;
+            }
+        }
+    }
+    candidates[selector % candidates.len()]
 }
 
 /// Direct-mapped, lock-free prefix -> backend cache.
@@ -196,9 +208,10 @@ fn least_loaded<'a>(candidates: &[&'a Arc<Backend>], rr: &AtomicUsize) -> &'a Ar
 /// has to sit on the per-request hot path. One relaxed atomic load and one
 /// relaxed store beats any map with a lock in front of it.
 ///
-/// Slot encoding: `(tag << 16) | uid`, where `tag` is the upper 48 bits of the
+/// Slot encoding: `(tag << 32) | uid`, where `tag` is the upper 32 bits of the
 /// hash. Zero means empty, so the one hash that would encode to zero is simply
-/// never cached.
+/// never cached. A 32-bit tag leaves a 2^-32 chance that a colliding prefix is
+/// mistaken for a hit, which costs one misrouted request and no correctness.
 struct AffinityCache {
     slots: Box<[AtomicU64]>,
     mask: usize,
@@ -216,7 +229,7 @@ impl AffinityCache {
 
     #[inline]
     fn encode(hash: u64, uid: BackendUid) -> u64 {
-        ((hash >> 16) << 16) | uid as u64
+        ((hash >> 32) << 32) | uid as u64
     }
 
     #[inline]
@@ -226,8 +239,8 @@ impl AffinityCache {
             return None;
         }
         // Confirm the slot belongs to this hash and not a colliding one.
-        if slot >> 16 == hash >> 16 {
-            Some(slot as u16)
+        if slot >> 32 == hash >> 32 {
+            Some(slot as BackendUid)
         } else {
             None
         }
@@ -393,7 +406,7 @@ model_list:
         cache.put(0x1234_5678_9abc_def0, 7);
         assert_eq!(cache.get(0x1234_5678_9abc_def0), Some(7));
         // Same slot index, different tag => miss, not a wrong answer.
-        let colliding = 0x1234_5678_9abc_def0u64 ^ (1 << 20);
+        let colliding = 0x1234_5678_9abc_def0u64 ^ (1 << 40);
         assert_eq!(
             colliding as usize & cache.mask,
             0x1234_5678_9abc_def0usize & cache.mask

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@
 use arc_swap::ArcSwap;
 use bytes::Bytes;
 use http_body_util::Full;
+use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use std::path::PathBuf;
@@ -13,7 +14,9 @@ use std::time::{Duration, Instant};
 use crate::registry::{Interner, Registry};
 use crate::router::Router;
 
-pub type HttpClient = Client<HttpConnector, Full<Bytes>>;
+/// Speaks both schemes: cluster-local vLLM nodes are plain HTTP, but a config
+/// may equally point at a TLS-terminated or hosted endpoint.
+pub type HttpClient = Client<HttpsConnector<HttpConnector>, Full<Bytes>>;
 
 pub struct AppState {
     /// Swapped wholesale on reload; readers never block.


### PR DESCRIPTION
## Correctness

Three bugs where documented behaviour could not work, each verified against a mock upstream before and after:

- **Audio endpoints were unusable.** Listed as proxied, but every body was parsed as JSON and the content-type forced to `application/json`, so the multipart bodies those routes require always 400'd. Adds a multipart field *locator* that reads `model` and leaves the upload byte-for-byte intact.
- **Upstream errors were swallowed.** A 5xx retried whenever `attempt < max_retries`, so with no alternative backend left the response was discarded for a synthetic 502 — on a single-node pool, every error. Now retries only when another backend actually exists.
- **`https://` backends could never connect.** Config validation accepted them but the client had no TLS connector. Adds `HttpsConnector` with system roots, falling back to the bundled Mozilla set. Verified against the real api.openai.com.

Plus: response `content-length` survives the hop (was forcing chunked encoding on every non-streaming completion), case-insensitive bearer scheme per RFC 7235, 413 vs 400 for oversized-vs-aborted uploads, honest success/failure counters, `BackendUid` widened to u32, and two allocations removed from the routing path.

## Deployment

- Reloads on config file change as well as SIGHUP — under k8s nothing sends SIGHUP when a ConfigMap is edited, so the only alternative was a rollout restart that drops in-flight generations.
- arm64-native Dockerfile, non-root, with ca-certificates so the TLS fix actually works in the image.
- CI tests on `arc-azrtydxb`, publishes to zot from `arc-azrtydxb-publish`, following the novamail pattern. Only main and tags produce an image.
- Manifests target spark2's direct replica endpoint rather than the higress gateway, so this proxy does its own prefix-affinity routing instead of the gateway round-robining replicas.

## Performance

`TODO.md` records the investigation. Streaming is capped at ~650k frames/s by the pooled client's per-frame task handoff; this proxy's own per-request work is ~2% of a request. Three micro-optimisations were implemented, measured, and reverted — the numbers are kept in the code so they are not retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)